### PR TITLE
Fix the Basque translation of the filenames that are generated when you grab the whole screen

### DIFF
--- a/po/eu.po
+++ b/po/eu.po
@@ -313,7 +313,7 @@ msgstr "Pantaila-argazkia.png"
 #: ../src/screenshot-filename-builder.c:143
 #, c-format
 msgid "Screenshot from %s.%s"
-msgstr "%s.%s(r)en pantaila-argazkia"
+msgstr "Pantaila-argazkia_%s.%s"
 
 #. translators: this is the name of the file that gets
 #. * made up with the screenshot if the entire screen is
@@ -321,7 +321,7 @@ msgstr "%s.%s(r)en pantaila-argazkia"
 #: ../src/screenshot-filename-builder.c:150
 #, c-format
 msgid "Screenshot from %s - %d.%s"
-msgstr "%s - %d.%s(r)en pantaila-argazkia"
+msgstr "Pantaila-argazkia_%s_%d.%s"
 
 #: ../src/screenshot-interactive-dialog.c:156
 msgid "None"


### PR DESCRIPTION
The current translation creates filenames like this:
2018-02-18 12-35-26.png(r)en pantaila-argazkia

With this fix we will get correct filenames like this:
Pantaila-argazkia_2018-02-18 12-35-26.png

I used the upstream translations of the strings:
https://github.com/GNOME/gnome-screenshot/blob/master/po/eu.po